### PR TITLE
Update for Elasticsearch 7.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.0
+
+references:
+  defaults: &defaults
+    docker:
+      - image: docker:18-git
+    working_directory: ~/docker-elasticsearch-ci
+
+jobs:
+  build: &build
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker build -t carwow/elasticsearch-ci:7.6.1 image/
+  publish: &publish
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: echo -n $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+      - run: docker push carwow/elasticsearch-ci:7.6.1
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: master
+
+      - publish:
+          filters:
+            branches:
+              only: master

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BASE_TAG:=carwow/elasticsearch-ci
-VERSION_TAG:=$(BASE_TAG):5.5.1
+VERSION_TAG:=$(BASE_TAG):7.6.1
 
 build:
 		docker build -t $(VERSION_TAG) image/

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.1
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 


### PR DESCRIPTION
Bump from 5.5.1 -> 7.6.1
Set up build and publish via CircleCI

No support for supporting multiple versions, but could do in a separate PR if we wanted to.